### PR TITLE
ci(workflows): publish artifacts before release creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,7 @@ jobs:
           fi
       - run: |
           export STAGING=$(printf "%s" $(./gradlew stagingPath --quiet))
+          find build -name '*.toml'
           gh release create ${{ github.event.workflow_run.head_sha }} --generate-notes $STAGING/* --verify-tag
         if: ${{ steps.detect-tag.outputs.is_tag == 'true' }}
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,8 +53,8 @@ jobs:
             echo "is_tag=false" >> "$GITHUB_OUTPUT"
           fi
       - run: |
+          ./gradlew publishAllPublicationsToStagingRepository
           export STAGING=$(printf "%s" $(./gradlew stagingPath --quiet))
-          find build -name '*.toml'
           gh release create ${{ github.event.workflow_run.head_sha }} --generate-notes $STAGING/* --verify-tag
         if: ${{ steps.detect-tag.outputs.is_tag == 'true' }}
         env:

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,11 @@ build:
 .PHONY: merge
 merge: merge-head push
 	@if gh pr view --json number > /dev/null 2>&1; then \
+		# PR exists: run full CI first, then update PR message to save Copilot calls \
 		$(MAKE) watch-full create-pr; \
 	else \
-		$(MAKE) create-pr watch-full; \
+		# No PR: create a minimal PR (no Copilot), run full CI, then generate message \
+		$(MAKE) create-pr-minimal watch-full create-pr; \
 	fi
 	@$(MAKE) merge-squash
 
@@ -51,6 +53,20 @@ create-pr: build
 		GH_PAGER=cat gh pr view; \
 	fi; \
 	rm -rf "$$tmp_dir"
+
+.PHONY: create-pr-minimal
+# Create a minimal PR without invoking Copilot. Still requires local build success first.
+create-pr-minimal: build
+	@if gh pr view --json number > /dev/null 2>&1; then \
+		printf '%s\n' "PR already exists; skipping minimal creation."; \
+	else \
+		title=$$(git log -1 --pretty=%s | head -n1); \
+		[ -n "$$title" ] || title="chore: open PR"; \
+		body="Temporary PR. Running full CI; description will be updated after success."; \
+		gh pr create --title "$$title" --body "$$body" || exit 0; \
+		printf '%s\n' "PR created (minimal)."; \
+		GH_PAGER=cat gh pr view; \
+	fi
 
 push:
 	git push


### PR DESCRIPTION
- added publishAllPublicationsToStagingRepository to release workflow 
so staged artifacts exist before gh release
- extended merge flow with create-pr-minimal to run CI and update PR 
messaging safely before full Copilot-run
