### PR TITLE
ci(build): enable signing for version catalog publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ publicationLegal {
 }
 
 mavenPublishing {
-  // signAllPublications()
+  signAllPublications()
   configure(VersionCatalog())
   publishToMavenCentral(false, DeploymentValidation.VALIDATED)
 }


### PR DESCRIPTION
- Un-comment signAllPublications so catalog releases are properly signed
- Preserve the existing Maven Central publishing configuration unchanged
